### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/src/MyContacts.Android/Properties/AndroidManifest.xml
+++ b/src/MyContacts.Android/Properties/AndroidManifest.xml
@@ -11,7 +11,10 @@
 	<uses-permission android:name="android.permission.READ_PHONE_STATE" />
 	<uses-permission android:name="android.permission.READ_LOGS" />
 	<application android:label="@string/app_name" android:theme="@style/MyTheme">
-		<!-- Put your Google Maps V2 API Key here. -->
+    <uses-library
+      android:name="org.apache.http.legacy"
+      android:required="false" />
+    <!-- Put your Google Maps V2 API Key here. -->
 		<meta-data android:name="com.google.android.maps.v2.API_KEY" android:value="AIzaSyB9kZU_zfTpbAV9MPb1GSCJeF93yAElvw4" />
 		<meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
 	</application>


### PR DESCRIPTION
Google  Maps is not running in older Android versions. We should add this setting to support older versions.

I have tested with API 29 and API 28. Even the documentation says Api 28 and above are supported, I couldn't run on API 28 without this setting.

https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library